### PR TITLE
Added 'Store' component option, to be able to inject Vuex to Vue

### DIFF
--- a/option.go
+++ b/option.go
@@ -17,6 +17,7 @@ type Config struct {
 	Computed   *js.Object `js:"computed"`
 	Components *js.Object `js:"components"`
 	Filters    *js.Object `js:"filters"`
+	Store      *js.Object `js:"store"`
 
 	dataValue reflect.Value
 

--- a/vm.go
+++ b/vm.go
@@ -24,6 +24,8 @@ type VM struct {
 	ScopedSlots *js.Object   `js:"$scopedSlots"`
 	IsServer    bool         `js:"$isServer"`
 
+	Store       *js.Object   `js:"$store"` //Vuex store, in case option is enabled, see https://vuex.vuejs.org/guide/state.html
+
 	// Note existence of fields with setter methods, which won't show up in
 	// $data.
 	Setters *js.Object `js:"hvue_setters"`
@@ -61,6 +63,15 @@ func NewVM(opts ...ComponentOption) *VM {
 func El(selector string) ComponentOption {
 	return func(c *Config) {
 		c.El = selector
+	}
+}
+
+// Store enables the Vuex store option, as described here: https://vuex.vuejs.org/guide/state.html
+func Store() ComponentOption {
+	return func(c *Config) {
+		// Note: The Vuex store has to be already exposed to js.Global "store" with this name, the original
+		// implementation doesn't allow to provide another name
+		c.Store = js.Global.Get("store")
 	}
 }
 


### PR DESCRIPTION
As described here https://vuex.vuejs.org/guide/state.html, Vuex provides a mechanism to "inject" the store (a global single source of truth, closely interacting with Vue) into all child components from the root component.

This involves setting an additional option on Vue creation like this:

```
const app = new Vue({
  el: '#app',
  // provide the store using the "store" option.
  // this will inject the store instance to all child components.
  store,
  components: { Counter },
  template: `
    <div class="app">
      <counter></counter>
    </div>
  `
})
```

In order to achieve this, I'd added an additional ComponentOption `hvue.Store` (used on `NewVM` not on `NewComponent`.

Best regards, thanks for your great project.
As stated on Twitter, it is much more capable than hopherjs-vue.
